### PR TITLE
Fix static file serving on Render deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,10 +67,11 @@ def create_app(config_name='default'):
     template_folder = os.path.join(os.getcwd(), 'templates')
     static_folder = os.path.join(os.getcwd(), 'static')
     
-    # Use our own static file handling instead of Flask's built-in
+    # Use Flask's built-in static file handling, but we'll also have our own as fallback
     app = Flask(__name__, 
                 template_folder=template_folder,
-                static_folder=None)
+                static_folder=static_folder,
+                static_url_path='/static')
                 
     # Create hash regex converter for dynamic routes
     class HashConverter(BaseConverter):


### PR DESCRIPTION
Description:
  Fixes internal server error on Render deployment by re-enabling Flask's built-in static file handler.

  ## Summary
  - Fixed the BuildError exception in static file URLs by re-enabling Flask's static handling
  - This resolves the 500 Internal Server Error seen on the Render deployment
  - Combined with our previous fixes for data-formatter-bundle.js and Content Security Policy issues

  ## Technical Details
  The error was caused by using `static_folder=None` in the Flask app initialization, which disabled the built-in static file handler but didn't properly register an alternative static endpoint, causing template rendering to fail with a BuildError exception when using `url_for('static', ...)`.

